### PR TITLE
refactor(ts/Components/Title.ts): Fixed types

### DIFF
--- a/ts/Components/Title.ts
+++ b/ts/Components/Title.ts
@@ -1,28 +1,30 @@
 // Абстрактная фабрика и абстрактные методы
-type TitleTagType = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+type THTMLElements = HTMLElementTagNameMap[keyof HTMLElementTagNameMap]; 
 
-interface IComponentFactory {
-	create(type: TitleTagType, text: string): HTMLElement;
+type HeadingTitleTagType = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+interface IComponentFactory<T> {
+	create(type: keyof HTMLElementTagNameMap, text: string): T;
 	render(
-		componentType: string,
+		componentType: keyof HTMLElementTagNameMap,
 		text: string,
-		destination: HTMLElement,
-	): HTMLElement;
+		destination: THTMLElements,
+	): T;
 }
 
-export default class TitleFactory implements IComponentFactory {
-	public create(type: TitleTagType, text: string): HTMLElement {
-		let createdTitle: HTMLElement = document.createElement(type);
+export default class TitleFactory implements IComponentFactory<HTMLHeadingElement> {
+	public create(type: HeadingTitleTagType, text: string) {
+		let createdTitle = document.createElement(type);
 		createdTitle.textContent = text;
 
 		return createdTitle;
 	}
 
 	public render(
-		componentType: TitleTagType,
+		componentType: HeadingTitleTagType,
 		text: string,
-		destination: HTMLElement | null,
-	): HTMLElement {
+		destination: THTMLElements | null,
+	) {
 		const element = this.create(componentType, text);
 
 		if (destination) {


### PR DESCRIPTION
Изменение были внесены для более точного описание какой тип возвращают методы "create" и "render", а также какие типы должны принимать аргументы этих методов.

### Описание:

**Line 2:** Добавлен новый именованный союз `THTMLElements` всех типов HTML элементов.

#### Interface IComponentFactory

**Line 6:** `Interface IComponentFactory`: 
Добавлена переменная типа в дженерик для установки возвращаемого типа для всех методов, чтобы возвращаемые типы были равны возвращаемому значению. 

**Line 7:** Тип метода `create:`
Тип аргумента `type` изменено на союз всех HTML тегов `keyof HTMLElementTagNameMap`. Потому что значение которое передается в этот аргумент будет использовано для создание HMTL элемента, а значение должно быть всегда являться HTML тегом.

**Line 8:** Тип метода `render:` 
**Line 9:** Тип аргумента `componentType` изменено на союз всех HTML тегов  `keyof HTMLElementTagNameMap`. Сделано так потому что этот аргумент используется в качестве значение аргумента `type` в методе `create`, а он должен принимать только HTML теги, а не просто `string`.
**Line 11:** Тип аргумента `destination` изменено на тип `THTMLElements`, чтобы он мог принимать любой HTML тег с разными типами, а не только один HTML тег з одним `HTMLElement` типом.

#### Class TitleFactory

**Line 15:** Для класса `TitleFactory` используется интерфейс `IComponentFactory` который указывает какие типы можно указать. `TitleFactory` должен возвращать элемент заголовок, и интерфейсу передается тип `HTMLHeadingElement` который укажет методам что они должны возвращать заголовок, чтобы случайно не пропустить не тот элемент.

**Line 16:** Был удален возвращаемый тип `HTMLElement` метода `create`, потому что, тип будет указан с контекста интерфейса `IComponentFactory`.

**Line 27:** Был удален возвращаемый тип `HTMLElement` метода `render`, потому что, тип будет указан с контекста интерфейса `IComponentFactory`.
